### PR TITLE
Add Dictée

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This list does not try to cover:
 <details>
 <summary>Browse by platform</summary>
 
-- Linux: Buzz, Elograf, Epicenter Whispering, Handy, HNS, hyprwhspr, nerd-dictation, OpenWhispr, Speak to AI, Vibe, Vocalinux, Voquill, VOXD, whisper_dictation, whisper-writer
+- Linux: Buzz, Dictée, Elograf, Epicenter Whispering, Handy, HNS, hyprwhspr, nerd-dictation, OpenWhispr, Speak to AI, Vibe, Vocalinux, Voquill, VOXD, whisper_dictation, whisper-writer
 - macOS: Amical, Buzz, Epicenter Whispering, FluidVoice, FnKey, Handy, HNS, OpenSuperWhisper, OpenWhispr, Pindrop, Tambourine Voice, TypeWhisper, Vibe, VoiceInk, VoiceTypr, Voquill, whisper-writer
 - Windows: Amical, Buzz, Chirp, Epicenter Whispering, Handy, HNS, OmniDictate, OpenWhispr, Tambourine Voice, Vibe, VoiceTypr, Voquill, whisper-writer
 - Android: Offline Voice Input, Transcribro, Whisper IME
@@ -56,6 +56,7 @@ Most tools on this list support offline speech recognition. See `Mode` and `Engi
 | [Amical](https://github.com/amicalhq/amical) | macOS, Windows | Local | Whisper | Context-aware dictation that adapts formatting to the app you are using. |
 | [Buzz](https://github.com/chidiwilliams/buzz) | Linux, macOS, Windows | Local | Whisper, Whisper.cpp, Faster Whisper | Desktop app for microphone or file transcription; text stays in its own UI rather than typing into other apps. |
 | [Chirp](https://github.com/Whamp/chirp) | Windows | Local | Parakeet TDT | Dictates into Windows apps, runs on CPU only, and is aimed at locked-down corporate environments. |
+| [Dictée](https://github.com/rcspam/dictee) | Linux | Local | Parakeet TDT, Vosk, Faster Whisper | Push-to-talk Linux dictation with a KDE Plasma 6 widget, optional translation, regex post-processing rules, and multi-backend ASR support. |
 | [Elograf](https://github.com/papoteur-mga/elograf) | Linux | Local | Vosk (via nerd-dictation) | GUI tray frontend for nerd-dictation with model switching and timeout controls. |
 | [Epicenter Whispering](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) | Linux, macOS, Windows, Web | Hybrid | Whisper | Local-first dictation with a global shortcut and multiple Whisper providers; also available as a Chrome extension and web app. |
 | [FluidVoice](https://github.com/altic-dev/FluidVoice) | macOS | Hybrid | Parakeet, Apple Speech, Whisper | macOS dictation app that can type into any app and switch between local speech engines. |


### PR DESCRIPTION
Adds [Dictée](https://github.com/rcspam/dictee), a Linux push-to-talk voice dictation tool.

**Key features:**
- Three ASR backends: Parakeet TDT (NVIDIA, 25 languages), Vosk (lightweight, 9 languages), Faster Whisper (99 languages)
- KDE Plasma 6 widget with 5 animation styles and live audio visualization
- Optional translation via Google Translate, LibreTranslate, or Ollama
- Regex-based post-processing rules with per-language support
- Daemon-based architecture with preloaded models for low latency
- Packages for Debian/Ubuntu (.deb), Fedora/openSUSE (.rpm), and generic Linux (.tar.gz)