### PR TITLE
Add VoxType

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This list does not try to cover:
 <details>
 <summary>Browse by platform</summary>
 
-- Linux: Buzz, Elograf, Epicenter Whispering, Handy, HNS, hyprwhspr, nerd-dictation, OpenWhispr, Speak to AI, Vibe, Vocalinux, Voquill, VOXD, whisper_dictation, whisper-writer
+- Linux: Buzz, Elograf, Epicenter Whispering, Handy, HNS, hyprwhspr, nerd-dictation, OpenWhispr, Speak to AI, Vibe, Vocalinux, Voquill, VOXD, VoxType, whisper_dictation, whisper-writer
 - macOS: Amical, Buzz, Epicenter Whispering, FluidVoice, FnKey, Handy, HNS, OpenSuperWhisper, OpenWhispr, Pindrop, Tambourine Voice, TypeWhisper, Vibe, VoiceInk, VoiceTypr, Voquill, whisper-writer
 - Windows: Amical, Buzz, Chirp, Epicenter Whispering, Handy, HNS, OmniDictate, OpenWhispr, Tambourine Voice, Vibe, VoiceTypr, Voquill, whisper-writer
 - Android: Offline Voice Input, Transcribro, Whisper IME
@@ -79,6 +79,7 @@ Most tools on this list support offline speech recognition. See `Mode` and `Engi
 | [VoiceTypr](https://github.com/moinulmoin/voicetypr) | macOS, Windows | Local | Whisper-based | Voice-to-text dictation built with Tauri; the repository is open source, but binaries require a one-time license purchase. |
 | [Voquill](https://github.com/josiahsrc/voquill) | Linux, macOS, Windows | Hybrid | Whisper.cpp, BYOK cloud | Cross-platform voice typing with a personal glossary and AI-assisted cleanup. |
 | [VOXD](https://github.com/jakovius/voxd) | Linux | Local | Whisper.cpp | Linux dictation with GUI, tray, and CLI modes plus optional LLM post-processing. |
+| [VoxType](https://github.com/peteonrails/voxtype) | Linux | Local | Whisper.cpp, Parakeet, Moonshine, SenseVoice | Push-to-talk Linux dictation with seven engine choices, CJK support, and Wayland-optimized text insertion. |
 | [WhisperBoard](https://github.com/Saik0s/Whisperboard) | iOS | Local | Whisper.cpp | iOS app for recording speech and producing text with downloadable Whisper models. |
 | [Whisper IME](https://github.com/woheller69/whisperIME) | Android | Local | Whisper.cpp | Android keyboard and standalone app powered by Whisper, fully offline, and available on F-Droid. |
 | [whisper-writer](https://github.com/savbell/whisper-writer) | Linux, macOS, Windows | Hybrid | Faster Whisper, OpenAI API | Hotkey-driven dictation that auto-types into the active window with several recording modes. |

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Most tools on this list support offline speech recognition. See `Mode` and `Engi
 | [VoiceTypr](https://github.com/moinulmoin/voicetypr) | macOS, Windows | Local | Whisper-based | Voice-to-text dictation built with Tauri; the repository is open source, but binaries require a one-time license purchase. |
 | [Voquill](https://github.com/josiahsrc/voquill) | Linux, macOS, Windows | Hybrid | Whisper.cpp, BYOK cloud | Cross-platform voice typing with a personal glossary and AI-assisted cleanup. |
 | [VOXD](https://github.com/jakovius/voxd) | Linux | Local | Whisper.cpp | Linux dictation with GUI, tray, and CLI modes plus optional LLM post-processing. |
-| [VoxType](https://github.com/peteonrails/voxtype) | Linux | Local | Whisper.cpp, Parakeet, Moonshine, SenseVoice | Push-to-talk Linux dictation with seven engine choices, CJK support, and Wayland-optimized text insertion. |
+| [VoxType](https://github.com/peteonrails/voxtype) | Linux | Hybrid | Whisper.cpp, Parakeet, Moonshine, SenseVoice | Push-to-talk Linux dictation with seven engine choices, CJK support, and Wayland-optimized text insertion. |
 | [WhisperBoard](https://github.com/Saik0s/Whisperboard) | iOS | Local | Whisper.cpp | iOS app for recording speech and producing text with downloadable Whisper models. |
 | [Whisper IME](https://github.com/woheller69/whisperIME) | Android | Local | Whisper.cpp | Android keyboard and standalone app powered by Whisper, fully offline, and available on F-Droid. |
 | [whisper-writer](https://github.com/savbell/whisper-writer) | Linux, macOS, Windows | Hybrid | Faster Whisper, OpenAI API | Hotkey-driven dictation that auto-types into the active window with several recording modes. |


### PR DESCRIPTION
## Summary

- Add VoxType to the directory and Linux platform list.
- VoxType is a push-to-talk Linux dictation tool with seven engine choices, CJK support, and Wayland-optimized text insertion. It belongs here as an open-source, dictation-focused app.

## Checklist

- [x] The project is open source.
- [x] The project is focused on voice typing or dictation, not just general transcription.
- [x] The project is a usable app, keyboard, menu bar utility, or CLI tool rather than a library, SDK, or API.
- [x] I linked the source repository, not a landing page or app-store listing.
- [x] I added or updated the `Directory` row in alphabetical order.
- [x] I updated the `Browse by platform` block in alphabetical order.
- [x] I updated the `Platform Snapshot` counts if this change affects them. N/A — no Platform Snapshot section with counts exists yet.
- [x] The summary is concise, objective, and ends with a period.

## References

- Source repository: https://github.com/peteonrails/voxtype
- Relevant docs, release notes, or commit: https://github.com/peteonrails/voxtype#features
- Extra context: MIT license, 603 stars, actively maintained (last push 2026-04-01). Supports Whisper, Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, and Omnilingual engines. Local by default with optional remote server support (Hybrid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)