### PR TITLE
Add whisrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This list does not try to cover:
 <details>
 <summary>Browse by platform</summary>
 
-- Linux: Buzz, Elograf, Epicenter Whispering, Handy, HNS, hyprwhspr, nerd-dictation, OpenWhispr, Speak to AI, Vibe, Vocalinux, Voquill, VOXD, VoxType, whisper_dictation, whisper-writer
+- Linux: Buzz, Elograf, Epicenter Whispering, Handy, HNS, hyprwhspr, nerd-dictation, OpenWhispr, Speak to AI, Vibe, Vocalinux, Voquill, VOXD, VoxType, whisper_dictation, whisper-writer, whisrs
 - macOS: Amical, Buzz, Epicenter Whispering, FluidVoice, FnKey, Ghost Pepper, Handy, HNS, OpenSuperWhisper, OpenWhispr, Pindrop, Tambourine Voice, TypeWhisper, Vibe, VoiceInk, VoiceTypr, Voquill, whisper-writer
 - Windows: Amical, Buzz, Chirp, Epicenter Whispering, Handy, HNS, OmniDictate, OpenWhispr, Tambourine Voice, Vibe, VoiceTypr, Voquill, whisper-writer
 - Android: Offline Voice Input, Transcribro, Whisper IME
@@ -85,6 +85,7 @@ Most tools on this list support offline speech recognition. See `Mode` and `Engi
 | [Whisper IME](https://github.com/woheller69/whisperIME)<br/><br/>![stars](https://img.shields.io/github/stars/woheller69/whisperIME?style=plastic&label=%E2%98%85) | Android | Local | Whisper.cpp | Android keyboard and standalone app powered by Whisper, fully offline, and available on F-Droid. |
 | [whisper-writer](https://github.com/savbell/whisper-writer)<br/><br/>![stars](https://img.shields.io/github/stars/savbell/whisper-writer?style=plastic&label=%E2%98%85) | Linux, macOS, Windows | Hybrid | Faster Whisper, OpenAI API | Hotkey-driven dictation that auto-types into the active window with several recording modes. |
 | [whisper_dictation](https://github.com/themanyone/whisper_dictation)<br/><br/>![stars](https://img.shields.io/github/stars/themanyone/whisper_dictation?style=plastic&label=%E2%98%85) | Linux | Local | Whisper.cpp | Feature-rich Linux voice keyboard with dictation, voice commands, and webcam integration. |
+| [whisrs](https://github.com/y0sif/whisrs)<br/><br/>![stars](https://img.shields.io/github/stars/y0sif/whisrs?style=plastic&label=%E2%98%85) | Linux | Hybrid | Whisper.cpp, Groq Whisper, Deepgram Nova, OpenAI Whisper | Linux dictation for Wayland and X11 with hotkey toggle, offline and cloud backends, and window-aware text injection. |
 
 ## Related Projects
 


### PR DESCRIPTION
Adds [whisrs](https://github.com/y0sif/whisrs) — a Linux-first voice-to-text dictation tool written in Rust.

**Directory row** added at the bottom of the table (alphabetical: after `whisper_dictation`); also added to the Linux line in the *Browse by platform* block.

### How whisrs fits the inclusion criteria

- **Open source** — MIT license ([LICENSE](https://github.com/y0sif/whisrs/blob/main/LICENSE)).
- **Voice typing focused** — primary workflow is hotkey → speak → text appears at the cursor in the active app via a virtual keyboard (uinput).
- **Usable as a product** — published binaries, AUR (`whisrs-git`), Nix flake, [crates.io](https://crates.io/crates/whisrs), and an interactive `whisrs setup` flow.
- **Still available / actively maintained** — daily-driven by the maintainer; latest release [v0.1.9](https://github.com/y0sif/whisrs/releases/tag/v0.1.9).
- **Maturity** — 9 tagged releases, a working install path on multiple distros, community-confirmed on Hyprland (Arch), GNOME Wayland (Ubuntu 24.04, Arch), and Xorg (Ubuntu 24.04). Star count is currently below the soft 50-star floor, but I believe the packaging maturity, tagged releases, and breadth of supported environments cover the spirit of the bar. Happy to defer if you'd prefer to wait until that grows.

### Entry summary

| Field | Value |
|---|---|
| Platforms | Linux |
| Mode | Hybrid |
| Engine | Whisper.cpp, Groq Whisper, Deepgram Nova, OpenAI Whisper |
| Summary | Linux dictation for Wayland and X11 with hotkey toggle, offline and cloud backends, and window-aware text injection. |

### Disclosure

I am the author and maintainer of whisrs.