### PR TITLE
Add gigastt

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ This list does not try to cover:
 <details>
 <summary>Browse by platform</summary>
 
-- Linux: Buzz, Elograf, Epicenter Whispering, Handy, HNS, hyprwhspr, nerd-dictation, OpenWhispr, Speak to AI, Vibe, Vocalinux, Voquill, VOXD, VoxType, whisper_dictation, whisper-writer
-- macOS: Amical, Buzz, Epicenter Whispering, FluidVoice, FnKey, Ghost Pepper, Handy, HNS, OpenSuperWhisper, OpenWhispr, Pindrop, Tambourine Voice, TypeWhisper, Vibe, VoiceInk, VoiceTypr, Voquill, whisper-writer
+- Linux: Buzz, Elograf, Epicenter Whispering, gigastt, Handy, HNS, hyprwhspr, nerd-dictation, OpenWhispr, Speak to AI, Vibe, Vocalinux, Voquill, VOXD, VoxType, whisper_dictation, whisper-writer
+- macOS: Amical, Buzz, Epicenter Whispering, FluidVoice, FnKey, Ghost Pepper, gigastt, Handy, HNS, OpenSuperWhisper, OpenWhispr, Pindrop, Tambourine Voice, TypeWhisper, Vibe, VoiceInk, VoiceTypr, Voquill, whisper-writer
 - Windows: Amical, Buzz, Chirp, Epicenter Whispering, Handy, HNS, OmniDictate, OpenWhispr, Tambourine Voice, Vibe, VoiceTypr, Voquill, whisper-writer
 - Android: Offline Voice Input, Transcribro, Whisper IME
 - iOS: WhisperBoard
@@ -72,6 +72,7 @@ Most tools on this list support offline speech recognition. See `Mode` and `Engi
 | [FluidVoice](https://github.com/altic-dev/FluidVoice)<br/><br/>![stars](https://img.shields.io/github/stars/altic-dev/FluidVoice?style=plastic&label=%E2%98%85) | macOS | Hybrid | Parakeet, Apple Speech, Whisper | macOS dictation app that can type into any app and switch between local speech engines. |
 | [FnKey](https://github.com/evoleinik/fnkey)<br/><br/>![stars](https://img.shields.io/github/stars/evoleinik/fnkey?style=plastic&label=%E2%98%85) | macOS | Hybrid | Deepgram Nova-3, Groq Whisper | Rust menu bar app that activates the microphone only while holding Fn, with real-time streaming and batch cloud backends. |
 | [Ghost Pepper](https://github.com/matthartman/ghost-pepper)<br/><br/>![stars](https://img.shields.io/github/stars/matthartman/ghost-pepper?style=plastic&label=%E2%98%85) | macOS | Local | WhisperKit | Hold-to-talk menu bar dictation with local LLM cleanup of filler words; runs entirely on Apple Silicon. |
+| [gigastt](https://github.com/ekhodzitsky/gigastt)<br/><br/>![stars](https://img.shields.io/github/stars/ekhodzitsky/gigastt?style=plastic&label=%E2%98%85) | Linux, macOS | Local | GigaAM v3 | Self-hosted Russian speech-to-text server with REST, WebSocket, and SSE streaming APIs plus a CLI for file, batch, and watch-folder transcription. |
 | [Handy](https://github.com/cjpais/Handy)<br/><br/>![stars](https://img.shields.io/github/stars/cjpais/Handy?style=plastic&label=%E2%98%85) | Linux, macOS, Windows | Local | Whisper.cpp, Parakeet TDT | Shortcut-driven offline dictation built with Tauri and supporting several ASR model families. |
 | [HNS](https://github.com/primaprashant/hns)<br/><br/>![stars](https://img.shields.io/github/stars/primaprashant/hns?style=plastic&label=%E2%98%85) | Linux, macOS, Windows | Local | Faster Whisper | CLI tool that records from your mic, transcribes locally, and copies the result to the clipboard. |
 | [hyprwhspr](https://github.com/goodroot/hyprwhspr)<br/><br/>![stars](https://img.shields.io/github/stars/goodroot/hyprwhspr?style=plastic&label=%E2%98%85) | Linux | Hybrid | Whisper.cpp, Parakeet, BYOK cloud | Push-to-talk Linux dictation with a visualizer plus Waybar and systemd integration. |


### PR DESCRIPTION
## Summary

- Adds [gigastt](https://github.com/ekhodzitsky/gigastt) to the `Directory` table (between Ghost Pepper and Handy) and to the Linux and macOS lines in `Browse by platform`.
- gigastt is a local, offline Russian speech-to-text server written in Rust (GigaAM v3 via ONNX Runtime, MIT license). It ships as a single binary with a CLI (`transcribe`, `transcribe-batch`, `watch` for folder automation) and REST / WebSocket / SSE streaming APIs designed for real-time dictation clients, with Swift/Kotlin/Python/Node bindings.
- **Self-submission:** I am the author and maintainer of gigastt.
- **Scope note for transparency:** gigastt is a server + CLI rather than a type-into-the-active-app desktop tool — closest in spirit to Buzz or Vibe on this list (transcription product, text stays in its own output). Its streaming APIs are built to power voice-typing integrations. Happy to withdraw if you judge it out of scope.
- **Maturity note:** the repo is ~3.5 months old with 26 stars (below the ~50 soft floor), but has regular tagged releases (currently v2.13.0), a working install path via `cargo install gigastt` / Homebrew / Docker, published crates, and CI on every PR.

## Checklist

- [x] The project is open source.
- [x] The project is focused on voice typing or dictation, not just general transcription.
- [x] The project is a usable app, keyboard, menu bar utility, or CLI tool rather than a library, SDK, or API.
- [x] The project meets the minimum maturity bar in [CONTRIBUTING.md](../CONTRIBUTING.md) (rough guideline: ~50+ stars or equivalent real-user signal, ~3+ months old, and a tagged release or working install path).
- [x] If I am the project's author or a maintainer, I have disclosed that in the summary above.
- [x] I linked the source repository, not a landing page or app-store listing.
- [x] I added or updated the `Directory` row in alphabetical order.
- [x] I updated the `Browse by platform` block in alphabetical order.
- [x] The summary is concise, objective, and ends with a period.

## References

- Source repository: https://github.com/ekhodzitsky/gigastt
- Relevant docs, release notes, or commit: https://ekhodzitsky.github.io/gigastt/ · https://crates.io/crates/gigastt · https://github.com/ekhodzitsky/gigastt/releases
- Extra context: CI: https://github.com/ekhodzitsky/gigastt/actions · License: MIT
