### PR TITLE
Add TalkType

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This list does not try to cover:
 <details>
 <summary>Browse by platform</summary>
 
-- Linux: Buzz, Elograf, Epicenter Whispering, Handy, HNS, hyprwhspr, nerd-dictation, OpenWhispr, Speak to AI, Vibe, Vocalinux, Voquill, VOXD, VoxType, whisper_dictation, whisper-writer
+- Linux: Buzz, Elograf, Epicenter Whispering, Handy, HNS, hyprwhspr, nerd-dictation, OpenWhispr, Speak to AI, TalkType, Vibe, Vocalinux, Voquill, VOXD, VoxType, whisper_dictation, whisper-writer
 - macOS: Amical, Buzz, Epicenter Whispering, FluidVoice, FnKey, Ghost Pepper, Handy, HNS, OpenSuperWhisper, OpenWhispr, Pindrop, Tambourine Voice, TypeWhisper, Vibe, VoiceInk, VoiceTypr, Voquill, whisper-writer, Yap
 - Windows: Amical, Buzz, Chirp, Epicenter Whispering, Handy, HNS, OmniDictate, OpenWhispr, Tambourine Voice, Vibe, VoiceTypr, Voquill, whisper-writer
 - Android: Offline Voice Input, Transcribro, Whisper IME
@@ -82,6 +82,7 @@ Most tools on this list support offline speech recognition. See `Mode` and `Engi
 | [OpenWhispr](https://github.com/OpenWhispr/openwhispr)<br/><br/>![stars](https://img.shields.io/github/stars/OpenWhispr/openwhispr?style=plastic&label=%E2%98%85) | Linux, macOS, Windows | Hybrid | Whisper.cpp, Parakeet, BYOK cloud | Cross-platform dictation with local models, optional cloud providers, and a custom dictionary. |
 | [Pindrop](https://github.com/watzon/pindrop)<br/><br/>![stars](https://img.shields.io/github/stars/watzon/pindrop?style=plastic&label=%E2%98%85) | macOS | Local | WhisperKit | Offline menu bar dictation app with optional AI-based transcript cleanup. |
 | [Speak to AI](https://github.com/AshBuk/speak-to-ai)<br/><br/>![stars](https://img.shields.io/github/stars/AshBuk/speak-to-ai?style=plastic&label=%E2%98%85) | Linux | Local | Whisper.cpp | Minimal Linux dictation tool that inserts text into the active window and can also run from the CLI. |
+| [TalkType](https://github.com/ronb1964/TalkType)<br/><br/>![stars](https://img.shields.io/github/stars/ronb1964/TalkType?style=plastic&label=%E2%98%85) | Linux | Local | Faster Whisper | Tray-based push-to-talk dictation with native Wayland hotkeys via /dev/input, packaged as AppImage, deb, rpm, and AUR. |
 | [Tambourine Voice](https://github.com/kstonekuan/tambourine-voice)<br/><br/>![stars](https://img.shields.io/github/stars/kstonekuan/tambourine-voice?style=plastic&label=%E2%98%85) | macOS, Windows | Hybrid | Faster Whisper, BYOK cloud | Voice interface for any app with configurable STT and LLM providers. |
 | [Transcribro](https://github.com/soupslurpr/Transcribro)<br/><br/>![stars](https://img.shields.io/github/stars/soupslurpr/Transcribro?style=plastic&label=%E2%98%85) | Android | Local | Whisper.cpp | Private and on-device speech recognition keyboard and service for Android. |
 | [TypeWhisper](https://github.com/TypeWhisper/typewhisper-mac)<br/><br/>![stars](https://img.shields.io/github/stars/TypeWhisper/typewhisper-mac?style=plastic&label=%E2%98%85) | macOS | Hybrid | Whisper (local and/or cloud) | Voice typing app with both local and cloud engine options. |


### PR DESCRIPTION
Adding TalkType, a push-to-talk dictation app for Linux.

- Repo: https://github.com/ronb1964/TalkType
- License: MIT
- Engine: Faster Whisper, fully offline
- Platform: Linux (Wayland and X11)

How it differs from the other Linux entries: the global hotkey is read from `/dev/input` below the compositor, rather than through X11 key grabs or `pynput`. That means push-to-talk works on GNOME, KDE, Sway and Hyprland without needing an X11 session. It runs as a GTK tray app with an optional GNOME Shell extension.

**On the maturity bar** — it is at 17 stars, below the ~50 guideline, so I would rather flag that myself than have you find it. Against the "another clear signal of real users" alternative:

- Packaged in a distro: on the AUR as `talktype-appimage`, plus `.deb` and `.rpm` builds
- First public commit August 2025 (12 months), 31 tagged releases, currently v0.7.2
- ~1,100 release downloads across all assets
- Non-author participants in both the issue tracker and Discussions

Completely understand if that does not clear the bar. Happy to resubmit later if you would rather wait for more traction.

Followed CONTRIBUTING.md: alphabetical placement in the Directory table (between Speak to AI and Tambourine Voice) and added to the Linux line of Browse by platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)