### PR TITLE
Add SpeakType

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This list does not try to cover:
 
 - Linux: Buzz, Elograf, Epicenter Whispering, Handy, HNS, hyprwhspr, nerd-dictation, OpenWhispr, Speak to AI, Vibe, Vocalinux, Voquill, VOXD, VoxType, whisper_dictation, whisper-writer
 - macOS: Amical, Buzz, Epicenter Whispering, FluidVoice, FnKey, Ghost Pepper, Handy, HNS, OpenSuperWhisper, OpenWhispr, Pindrop, Tambourine Voice, TypeWhisper, Vibe, VoiceInk, VoiceTypr, Voquill, whisper-writer, Yap
-- Windows: Amical, Buzz, Chirp, Epicenter Whispering, Handy, HNS, OmniDictate, OpenWhispr, Tambourine Voice, Vibe, VoiceTypr, Voquill, whisper-writer
+- Windows: Amical, Buzz, Chirp, Epicenter Whispering, Handy, HNS, OmniDictate, OpenWhispr, SpeakType, Tambourine Voice, Vibe, VoiceTypr, Voquill, whisper-writer
 - Android: Offline Voice Input, Transcribro, Whisper IME
 - iOS: WhisperBoard
 
@@ -82,6 +82,7 @@ Most tools on this list support offline speech recognition. See `Mode` and `Engi
 | [OpenWhispr](https://github.com/OpenWhispr/openwhispr)<br/><br/>![stars](https://img.shields.io/github/stars/OpenWhispr/openwhispr?style=plastic&label=%E2%98%85) | Linux, macOS, Windows | Hybrid | Whisper.cpp, Parakeet, BYOK cloud | Cross-platform dictation with local models, optional cloud providers, and a custom dictionary. |
 | [Pindrop](https://github.com/watzon/pindrop)<br/><br/>![stars](https://img.shields.io/github/stars/watzon/pindrop?style=plastic&label=%E2%98%85) | macOS | Local | WhisperKit | Offline menu bar dictation app with optional AI-based transcript cleanup. |
 | [Speak to AI](https://github.com/AshBuk/speak-to-ai)<br/><br/>![stars](https://img.shields.io/github/stars/AshBuk/speak-to-ai?style=plastic&label=%E2%98%85) | Linux | Local | Whisper.cpp | Minimal Linux dictation tool that inserts text into the active window and can also run from the CLI. |
+| [SpeakType](https://github.com/wookat/speaktype)<br/><br/>![stars](https://img.shields.io/github/stars/wookat/speaktype?style=plastic&label=%E2%98%85) | Windows | Hybrid | SenseVoice, Parakeet TDT, Whisper.cpp, BYOK cloud | Hold-to-talk Windows dictation with offline models by default, correction-based dictionary learning, and phone-as-microphone input. |
 | [Tambourine Voice](https://github.com/kstonekuan/tambourine-voice)<br/><br/>![stars](https://img.shields.io/github/stars/kstonekuan/tambourine-voice?style=plastic&label=%E2%98%85) | macOS, Windows | Hybrid | Faster Whisper, BYOK cloud | Voice interface for any app with configurable STT and LLM providers. |
 | [Transcribro](https://github.com/soupslurpr/Transcribro)<br/><br/>![stars](https://img.shields.io/github/stars/soupslurpr/Transcribro?style=plastic&label=%E2%98%85) | Android | Local | Whisper.cpp | Private and on-device speech recognition keyboard and service for Android. |
 | [TypeWhisper](https://github.com/TypeWhisper/typewhisper-mac)<br/><br/>![stars](https://img.shields.io/github/stars/TypeWhisper/typewhisper-mac?style=plastic&label=%E2%98%85) | macOS | Hybrid | Whisper (local and/or cloud) | Voice typing app with both local and cloud engine options. |


### PR DESCRIPTION
Adds [SpeakType](https://github.com/wookat/speaktype) to the directory (Windows row) and the Windows platform list.

**Disclosure: I am the author of SpeakType** (per CONTRIBUTING.md self-submission note).

Facts for review:
- MIT licensed, source public: https://github.com/wookat/speaktype
- Hold-to-talk dictation into any Windows app; offline by default (SenseVoice), with Parakeet TDT 0.6B v3 and whisper.cpp as local options, plus optional BYOK OpenAI-compatible cloud providers (hence Hybrid)
- Tagged release with installer + portable binaries: https://github.com/wookat/speaktype/releases/tag/v0.17.0
- Extra features: correction-based dictionary learning, phone-as-microphone over LAN/relay, hands-free dictation mode

Honest maturity note: the project is young and does not yet meet the ~50-star soft floor. If you prefer to wait until it matures, feel free to close this PR - happy to resubmit later.