### PR TITLE
Add Iris Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This list does not try to cover:
 <summary>Browse by platform</summary>
 
 - Linux: Buzz, Elograf, Epicenter Whispering, Handy, HNS, hyprwhspr, nerd-dictation, OpenWhispr, Speak to AI, Vibe, Vocalinux, Voquill, VOXD, VoxType, whisper_dictation, whisper-writer
-- macOS: Amical, Buzz, Epicenter Whispering, FluidVoice, FnKey, Ghost Pepper, Handy, HNS, OpenSuperWhisper, OpenWhispr, Pindrop, Tambourine Voice, TypeWhisper, Vibe, VoiceInk, VoiceTypr, Voquill, whisper-writer, Yap
+- macOS: Amical, Buzz, Epicenter Whispering, FluidVoice, FnKey, Ghost Pepper, Handy, HNS, Iris Flow, OpenSuperWhisper, OpenWhispr, Pindrop, Tambourine Voice, TypeWhisper, Vibe, VoiceInk, VoiceTypr, Voquill, whisper-writer, Yap
 - Windows: Amical, Buzz, Chirp, Epicenter Whispering, Handy, HNS, OmniDictate, OpenWhispr, Tambourine Voice, Vibe, VoiceTypr, Voquill, whisper-writer
 - Android: Offline Voice Input, Transcribro, Whisper IME
 - iOS: WhisperBoard
@@ -75,6 +75,7 @@ Most tools on this list support offline speech recognition. See `Mode` and `Engi
 | [Handy](https://github.com/cjpais/Handy)<br/><br/>![stars](https://img.shields.io/github/stars/cjpais/Handy?style=plastic&label=%E2%98%85) | Linux, macOS, Windows | Local | Whisper.cpp, Parakeet TDT | Shortcut-driven offline dictation built with Tauri and supporting several ASR model families. |
 | [HNS](https://github.com/primaprashant/hns)<br/><br/>![stars](https://img.shields.io/github/stars/primaprashant/hns?style=plastic&label=%E2%98%85) | Linux, macOS, Windows | Local | Faster Whisper | CLI tool that records from your mic, transcribes locally, and copies the result to the clipboard. |
 | [hyprwhspr](https://github.com/goodroot/hyprwhspr)<br/><br/>![stars](https://img.shields.io/github/stars/goodroot/hyprwhspr?style=plastic&label=%E2%98%85) | Linux | Hybrid | Whisper.cpp, Parakeet, BYOK cloud | Push-to-talk Linux dictation with a visualizer plus Waybar and systemd integration. |
+| [Iris Flow](https://github.com/joyboy5477/IrisFlow)<br/><br/>![stars](https://img.shields.io/github/stars/joyboy5477/IrisFlow?style=plastic&label=%E2%98%85) | macOS | Hybrid | Deepgram Nova-3 | Overlay dictation for Apple Silicon: hold Left-Ctrl, speak, and text is pasted into the focused app. |
 | [nerd-dictation](https://github.com/ideasman42/nerd-dictation)<br/><br/>![stars](https://img.shields.io/github/stars/ideasman42/nerd-dictation?style=plastic&label=%E2%98%85) | Linux | Local | Vosk | Hackable offline dictation that types into any window via simulated keystrokes. |
 | [Offline Voice Input (Android)](https://github.com/notune/android_transcribe_app)<br/><br/>![stars](https://img.shields.io/github/stars/notune/android_transcribe_app?style=plastic&label=%E2%98%85) | Android | Local | Parakeet TDT | Offline Android voice input keyboard with live subtitles and a privacy-first focus. |
 | [OmniDictate](https://github.com/gurjar1/OmniDictate)<br/><br/>![stars](https://img.shields.io/github/stars/gurjar1/OmniDictate?style=plastic&label=%E2%98%85) | Windows | Local | Whisper | Desktop dictation tool aimed at type-anywhere workflows. |


### PR DESCRIPTION
Self-submission. I am the author of Iris Flow.

Adds [Iris Flow](https://github.com/joyboy5477/IrisFlow) to the directory (alphabetical, after hyprwhspr) and to the macOS platform line.

- Open source (MIT)
- Voice typing: hold Left-Ctrl, speak, text is pasted into the focused Mac app
- Working install path in the README (clone, npm install, npm run install:mac)
- Hybrid: Deepgram Nova-3 with optional BYO LLM keys
- Apple Silicon only

The repo is new, so it does not yet meet the ~50 stars / ~3 months guideline. Submitting anyway because the app is usable today and this is the closest curated list for dictation tools.


Made with [Cursor](https://cursor.com)